### PR TITLE
tfxunit2junit.py: load log showing also stdout

### DIFF
--- a/tfxunit2junit.py
+++ b/tfxunit2junit.py
@@ -178,7 +178,8 @@ def main(args):
         # TODO: can there be more test suites in a single xunit file?
         for testcase in input_xml.testsuite[0].testcase:
             for log in testcase.logs.log:
-                if log.attrib['name'].endswith('.log'):
+                # STI produces error logs, with stderr output only, ignore them ideally
+                if log.attrib['name'].endswith('.log') and not log.attrib['name'].endswith('-err.log'):
                     logs = get_test_logs(log.attrib['href'])
                     if not logs:
                         logs = '(empty output)'


### PR DESCRIPTION
The STI generates 2 log file like:

ERROR-selinux-policy-fapolicyd-and-similar-err.log
ERROR-selinux-policy-fapolicyd-and-similar.log

The latter is better for the user as it displays stdout also.

Reported by @mmalik

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>